### PR TITLE
Add summary mode for Get Observation

### DIFF
--- a/senaite-openmrs/src/main/java/com/ozonehis/eip/openmrs/senaite/handlers/openmrs/ObservationHandler.java
+++ b/senaite-openmrs/src/main/java/com/ozonehis/eip/openmrs/senaite/handlers/openmrs/ObservationHandler.java
@@ -8,6 +8,7 @@
 package com.ozonehis.eip.openmrs.senaite.handlers.openmrs;
 
 import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.SummaryEnum;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import java.time.Instant;
 import java.util.Collections;
@@ -45,6 +46,7 @@ public class ObservationHandler {
                 .where(Observation.CODE.exactly().code(codeID))
                 .and(Observation.SUBJECT.hasId(subjectID))
                 .and(Observation.ENCOUNTER.hasId(encounterID))
+                .summaryMode(SummaryEnum.DATA)
                 // .and(Observation.DATE.exactly().second(observationDate)) // TODO: Fix date format passed
                 .returnBundle(Bundle.class)
                 .execute();

--- a/senaite-openmrs/src/test/java/com/ozonehis/eip/openmrs/senaite/handlers/openmrs/ObservationHandlerTest.java
+++ b/senaite-openmrs/src/test/java/com/ozonehis/eip/openmrs/senaite/handlers/openmrs/ObservationHandlerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.SummaryEnum;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.gclient.ICreate;
 import ca.uhn.fhir.rest.gclient.ICreateTyped;
@@ -98,6 +99,7 @@ class ObservationHandlerTest {
         when(iQuery.where(any(ICriterion.class))).thenReturn(iQuery);
         when(iQuery.and(any(ICriterion.class))).thenReturn(iQuery);
         when(iQuery.and(any(ICriterion.class))).thenReturn(iQuery);
+        when(iQuery.summaryMode(any(SummaryEnum.class))).thenReturn(iQuery);
         when(iQuery.returnBundle(Bundle.class)).thenReturn(iQuery);
         when(iQuery.execute()).thenReturn(bundle);
 


### PR DESCRIPTION
Removes the `text` block from Observation FHIR payload.

Note: Hack to fix the resource.id null issue